### PR TITLE
Implementa cadastro obrigatório ao iniciar

### DIFF
--- a/index.html
+++ b/index.html
@@ -2315,10 +2315,18 @@ document.getElementById('fechar-modal-reserva').addEventListener('click', ()=>{
           }
 
 
-          const userData = localStorage.getItem('userData');
-          if(!userData){
-            document.getElementById('firstAccessModal').classList.remove('hidden');
+          const cadastroKey = 'usuarioCadastro';
+          const savedCadastro = localStorage.getItem(cadastroKey);
+          const firstAccessModal = document.getElementById('firstAccessModal');
+          const loginForm = document.getElementById('login-form');
+          const app = document.getElementById('app');
+
+          if(!savedCadastro){
+            firstAccessModal.classList.remove('hidden');
+            loginForm.classList.add('hidden');
+            app.classList.add('hidden');
           }
+
           document.getElementById('firstAccessForm').addEventListener('submit', function(e) {
             e.preventDefault();
             const data = {
@@ -2326,8 +2334,9 @@ document.getElementById('fechar-modal-reserva').addEventListener('click', ()=>{
               email: document.getElementById('firstEmail').value.trim(),
               telefone: document.getElementById('firstPhone').value.trim()
             };
-            localStorage.setItem('userData', JSON.stringify(data));
-            document.getElementById('firstAccessModal').classList.add('hidden');
+            localStorage.setItem(cadastroKey, JSON.stringify(data));
+            firstAccessModal.classList.add('hidden');
+            loginForm.classList.remove('hidden');
           });
 
 
@@ -2353,7 +2362,7 @@ document.getElementById('fechar-modal-reserva').addEventListener('click', ()=>{
               inicializarCombos();
               popularModelFilters();
               registrarLog("Inicialização", "Dados carregados");
-              const storedUserData = localStorage.getItem('userData');
+              const storedUserData = localStorage.getItem('usuarioCadastro');
               if(storedUserData){
                 const uData = JSON.parse(storedUserData);
                 const licenseText = `ESTE PROGRAMA ESTÁ LICENCIADO PARA ${uData.nome} (${uData.email}, ${uData.telefone})`;


### PR DESCRIPTION
## Summary
- mostra a tela de **Cadastro Inicial** obrigatoriamente caso os dados não estejam no localStorage
- impede acesso ao login e à aplicação até salvar os dados
- guarda os dados em `localStorage` como `usuarioCadastro`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fa4f7a304832fae03d446c595ab91